### PR TITLE
docs: add comment to ServiceActionRequest message

### DIFF
--- a/proto/services/v1/services.proto
+++ b/proto/services/v1/services.proto
@@ -12,6 +12,7 @@ service HandlerService {
 
 message ServiceActionRequest  {
 
+  // The name of the Service to request (for a list of all services, use "systemd")
   string service_name = 1;
 
   enum UnitAction {


### PR DESCRIPTION
Added comment to clarify service_name field usage.